### PR TITLE
Refactor shared layout into reusable components

### DIFF
--- a/about.html
+++ b/about.html
@@ -41,22 +41,8 @@
     @media (prefers-reduced-motion: reduce) { .reveal, .hover-lift, .tilt-oscillate { transition:none!important; animation:none!important; } }
   </style>
 </head>
-<body class="text-ink antialiased">
-  <header id="site-header" class="sticky top-0 z-20 border-b border-stroke/70 bg-white/80 backdrop-blur">
-    <nav class="mx-auto max-w-5xl px-5">
-      <div class="flex h-14 items-center gap-4">
-        <a href="index.html" class="font-display text-lg tracking-tight">Aditya Rao</a>
-        <div class="ml-auto flex items-center gap-5 text-sm">
-          <a href="index.html" class="navlink">Home</a>
-          <span class="text-subink">About</span>
-          <a href="comingsoon.html" class="navlink">Blog</a>
-          <a href="creations.html" class="navlink">Creations</a>
-          <a href="contact.html" class="navlink">Contact</a>
-          <a href="contact.html#book" class="rounded-full bg-blue-600 px-3 py-1 text-white">Say hi</a>
-        </div>
-      </div>
-    </nav>
-  </header>
+<body class="text-ink antialiased" data-page="about">
+  <header data-component="site-header"></header>
 
 <main class="mx-auto max-w-5xl px-5 py-10">
 <header class="mb-8"><h1 class="font-display text-4xl leading-tight">About</h1>
@@ -104,46 +90,7 @@
 </section>
 </main>
 
-  <footer class="border-t border-stroke/70 py-8 text-xs text-subink">
-    <div class="mx-auto flex max-w-5xl items-center justify-between px-5">
-      <span>Today's Date: <span id="today"></span></span>
-    </div>
-  </footer>
+  <footer data-component="site-footer" data-footer-note="Today's Date:" data-footer-date-placement="inline"></footer>
 
-  <script>
-    const toReveal = Array.from(document.querySelectorAll('.reveal'));
-    const io = new IntersectionObserver((entries)=>{
-      entries.forEach(e=>{ if(e.isIntersecting){ e.target.classList.add('in-view'); io.unobserve(e.target); } });
-    }, { rootMargin:'0px 0px -10% 0px', threshold:0.12 });
-    toReveal.forEach((el,i)=>{ el.style.transitionDelay = `${Math.min(i*40,240)}ms`; io.observe(el); });
-
-    const headerEl = document.getElementById('site-header');
-    function onScroll(){ if(window.scrollY>4) headerEl.classList.add('scrolled'); else headerEl.classList.remove('scrolled'); }
-    onScroll(); window.addEventListener('scroll', onScroll, { passive:true });
-
-    function istTime(){ try { return new Intl.DateTimeFormat('en-IN', { timeStyle:'short', timeZone:'Asia/Kolkata' }).format(new Date()); } catch { return '--:--'; } }
-    function tick(){
-      const t = istTime();
-      document.querySelectorAll('[data-ist]').forEach(el=> el.textContent = `🕒 ${t} IST`);
-      const today = new Date().toISOString().slice(0,10);
-      const td = document.getElementById('today'); if (td) td.textContent = today;
-    }
-    tick(); setInterval(tick, 60000);
-
-    const copyBtn = document.getElementById('copy-email');
-    const emailLink = document.getElementById('email-link');
-    if (copyBtn && emailLink) copyBtn.addEventListener('click', async (e)=>{
-      e.preventDefault();
-      try { await navigator.clipboard.writeText(emailLink.textContent.trim()); copyBtn.textContent='Copied ✓'; setTimeout(()=>copyBtn.textContent='Copy',1500); } catch {}
-    });
-
-    const setBtn = document.getElementById('set-weather');
-    const weatherEl = document.getElementById('weather');
-    if (setBtn && weatherEl) setBtn.addEventListener('click', ()=>{
-      const temp = prompt('Temperature in °C (e.g., 29)');
-      const cond = prompt('Condition (e.g., Cloudy, Clear, Rain)');
-      if (temp) weatherEl.textContent = `${cond ? cond+' ' : ''}${temp}°C`;
-    });
-  </script>
-
+  <script src="assets/js/site.js" defer></script>
 </body></html>

--- a/assets/js/site.js
+++ b/assets/js/site.js
@@ -1,0 +1,231 @@
+const NAV_LINKS = [
+  { id: 'home', label: 'Home', href: 'index.html' },
+  { id: 'about', label: 'About', href: 'about.html' },
+  { id: 'blog', label: 'Blog', href: 'blog.html' },
+  { id: 'creations', label: 'Creations', href: 'creations.html' },
+  { id: 'contact', label: 'Contact', href: 'contact.html' }
+];
+
+const MORE_LINKS = [
+  { id: 'needs-wants', label: 'Needs & Wants', href: 'needs-wants.html' },
+  { id: 'now-someday', label: 'Now & Someday', href: 'now-someday.html' }
+];
+
+const CTA_LINK = { label: 'Say hi', href: 'contact.html#book' };
+
+function renderHeader(currentPage) {
+  const mount = document.querySelector('[data-component="site-header"]');
+  if (!mount) return;
+
+  mount.id = 'site-header';
+  mount.className = 'sticky top-0 z-20 border-b border-stroke/70 bg-white/80 backdrop-blur';
+
+  const navLinkClass = 'transition-colors text-subink hover:text-ink';
+
+  const renderNavItem = (item) => {
+    if (item.id === currentPage) {
+      return `<span class="text-subink" aria-current="page">${item.label}</span>`;
+    }
+    return `<a href="${item.href}" class="${navLinkClass}">${item.label}</a>`;
+  };
+
+  const moreActive = MORE_LINKS.some((item) => item.id === currentPage);
+  const moreMenu = `
+    <div class="relative" data-nav-more>
+      <button type="button" class="${navLinkClass} inline-flex items-center gap-1" aria-haspopup="true" aria-expanded="false">
+        <span${moreActive ? ' class="text-subink" aria-current="page"' : ''}>More</span>
+        <svg class="h-2.5 w-2.5" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 10 6">
+          <path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="m1 1 4 4 4-4" />
+        </svg>
+      </button>
+      <div class="absolute right-0 mt-2 hidden w-44 divide-y divide-stroke overflow-hidden rounded-lg border border-stroke bg-white text-sm shadow-card" data-nav-menu role="menu">
+        <ul class="py-2 text-ink">
+          ${MORE_LINKS.map((item) => {
+            if (item.id === currentPage) {
+              return `<li><span class="block bg-subtle px-4 py-2 text-subink">${item.label}</span></li>`;
+            }
+            return `<li><a href="${item.href}" class="block px-4 py-2 transition-colors hover:bg-subtle">${item.label}</a></li>`;
+          }).join('')}
+        </ul>
+      </div>
+    </div>
+  `;
+
+  const navItemsHtml = [
+    renderNavItem(NAV_LINKS[0]),
+    renderNavItem(NAV_LINKS[1]),
+    renderNavItem(NAV_LINKS[2]),
+    renderNavItem(NAV_LINKS[3]),
+    moreMenu,
+    renderNavItem(NAV_LINKS[4])
+  ].join('');
+
+  mount.innerHTML = `
+    <nav class="mx-auto max-w-5xl px-5">
+      <div class="flex h-14 items-center gap-4 text-sm">
+        <a href="index.html" class="font-display text-lg tracking-tight text-ink">Aditya Rao</a>
+        <div class="ml-auto flex items-center gap-5">
+          ${navItemsHtml}
+          <a href="${CTA_LINK.href}" class="rounded-full bg-blue-600 px-3 py-1 text-white">${CTA_LINK.label}</a>
+        </div>
+      </div>
+    </nav>
+  `;
+}
+
+function renderFooter() {
+  const mounts = document.querySelectorAll('[data-component="site-footer"]');
+  mounts.forEach((footer) => {
+    footer.className = 'border-t border-stroke/70 py-8 text-xs text-subink';
+    const wrapper = document.createElement('div');
+    wrapper.className = 'mx-auto flex max-w-5xl items-center justify-between px-5';
+
+    const placement = footer.dataset.footerDatePlacement || 'right';
+    const note = footer.dataset.footerNote || 'Made lightly.';
+    const showDate = footer.dataset.footerHideDate !== 'true';
+
+    if (placement === 'inline' && showDate) {
+      const span = document.createElement('span');
+      span.innerHTML = `${note} <span data-today id="today"></span>`;
+      wrapper.appendChild(span);
+    } else {
+      const leftSpan = document.createElement('span');
+      leftSpan.textContent = note;
+      wrapper.appendChild(leftSpan);
+      if (showDate) {
+        const rightSpan = document.createElement('span');
+        rightSpan.id = 'today';
+        rightSpan.setAttribute('data-today', '');
+        wrapper.appendChild(rightSpan);
+      }
+    }
+
+    footer.innerHTML = '';
+    footer.appendChild(wrapper);
+  });
+}
+
+function setupNavMenu() {
+  const more = document.querySelector('[data-nav-more]');
+  if (!more) return;
+
+  const button = more.querySelector('button');
+  const menu = more.querySelector('[data-nav-menu]');
+  if (!button || !menu) return;
+
+  button.addEventListener('click', (event) => {
+    event.preventDefault();
+    const isOpen = !menu.classList.contains('hidden');
+    menu.classList.toggle('hidden', isOpen);
+    button.setAttribute('aria-expanded', String(!isOpen));
+  });
+
+  document.addEventListener('click', (event) => {
+    if (!more.contains(event.target)) {
+      menu.classList.add('hidden');
+      button.setAttribute('aria-expanded', 'false');
+    }
+  });
+}
+
+function initReveal() {
+  const toReveal = Array.from(document.querySelectorAll('.reveal'));
+  if (!toReveal.length) return;
+
+  const io = new IntersectionObserver((entries) => {
+    entries.forEach((entry) => {
+      if (entry.isIntersecting) {
+        entry.target.classList.add('in-view');
+        io.unobserve(entry.target);
+      }
+    });
+  }, { rootMargin: '0px 0px -10% 0px', threshold: 0.12 });
+
+  toReveal.forEach((el, index) => {
+    el.style.transitionDelay = `${Math.min(index * 40, 240)}ms`;
+    io.observe(el);
+  });
+}
+
+function initHeaderScroll() {
+  const header = document.getElementById('site-header');
+  if (!header) return;
+
+  const onScroll = () => {
+    if (window.scrollY > 4) {
+      header.classList.add('scrolled');
+    } else {
+      header.classList.remove('scrolled');
+    }
+  };
+
+  onScroll();
+  window.addEventListener('scroll', onScroll, { passive: true });
+}
+
+function updateClock() {
+  const formatTime = () => {
+    try {
+      return new Intl.DateTimeFormat('en-IN', { timeStyle: 'short', timeZone: 'Asia/Kolkata' }).format(new Date());
+    } catch (error) {
+      return '--:--';
+    }
+  };
+
+  const tick = () => {
+    const time = formatTime();
+    document.querySelectorAll('[data-ist]').forEach((el) => {
+      el.textContent = `🕒 ${time} IST`;
+    });
+    const today = new Date().toISOString().slice(0, 10);
+    document.querySelectorAll('[data-today]').forEach((el) => {
+      el.textContent = today;
+    });
+  };
+
+  tick();
+  setInterval(tick, 60000);
+}
+
+function initClipboard() {
+  const button = document.getElementById('copy-email');
+  const emailLink = document.getElementById('email-link');
+  if (!button || !emailLink) return;
+
+  button.addEventListener('click', async (event) => {
+    event.preventDefault();
+    try {
+      await navigator.clipboard.writeText(emailLink.textContent.trim());
+      button.textContent = 'Copied ✓';
+      setTimeout(() => { button.textContent = 'Copy'; }, 1500);
+    } catch (error) {
+      // ignore clipboard errors silently
+    }
+  });
+}
+
+function initWeatherSetter() {
+  const button = document.getElementById('set-weather');
+  const display = document.getElementById('weather');
+  if (!button || !display) return;
+
+  button.addEventListener('click', () => {
+    const temp = prompt('Temperature in °C (e.g., 29)');
+    const condition = prompt('Condition (e.g., Cloudy, Clear, Rain)');
+    if (temp) {
+      display.textContent = `${condition ? `${condition} ` : ''}${temp}°C`;
+    }
+  });
+}
+
+(function initSite() {
+  const page = document.body ? document.body.dataset.page : '';
+  renderHeader(page || '');
+  renderFooter();
+  setupNavMenu();
+  initReveal();
+  initHeaderScroll();
+  updateClock();
+  initClipboard();
+  initWeatherSetter();
+})();

--- a/blog.html
+++ b/blog.html
@@ -37,22 +37,8 @@
     @media (prefers-reduced-motion: reduce) { .reveal, .hover-lift, .tilt-oscillate { transition:none!important; animation:none!important; } }
   </style>
 </head>
-<body class="text-ink antialiased">
-  <header id="site-header" class="sticky top-0 z-20 border-b border-stroke/70 bg-white/80 backdrop-blur">
-    <nav class="mx-auto max-w-5xl px-5">
-      <div class="flex h-14 items-center gap-4">
-        <a href="index.html" class="font-display text-lg tracking-tight">Aditya Rao</a>
-        <div class="ml-auto flex items-center gap-5 text-sm">
-          <a href="index.html" class="navlink">Home</a>
-          <a href="about.html" class="navlink">About</a>
-          <span class="text-subink">Blog</span>
-          <a href="creations.html" class="navlink">Creations</a>
-          <a href="contact.html" class="navlink">Contact</a>
-          <a href="contact.html#book" class="rounded-full bg-blue-600 px-3 py-1 text-white">Say hi</a>
-        </div>
-      </div>
-    </nav>
-  </header>
+<body class="text-ink antialiased" data-page="blog">
+  <header data-component="site-header"></header>
 
 <main class="mx-auto max-w-5xl px-5 py-10">
 <header class="mb-6"><h1 class="font-display text-4xl leading-tight">Blog</h1><p class="text-subink">Simple posts and notes.</p></header>
@@ -62,47 +48,7 @@
 </div>
 </main>
 
-  <footer class="border-t border-stroke/70 py-8 text-xs text-subink">
-    <div class="mx-auto flex max-w-5xl items-center justify-between px-5">
-      <span>Made lightly.</span>
-      <span id="today"></span>
-    </div>
-  </footer>
+  <footer data-component="site-footer" data-footer-note="Made lightly."></footer>
 
-  <script>
-    const toReveal = Array.from(document.querySelectorAll('.reveal'));
-    const io = new IntersectionObserver((entries)=>{
-      entries.forEach(e=>{ if(e.isIntersecting){ e.target.classList.add('in-view'); io.unobserve(e.target); } });
-    }, { rootMargin:'0px 0px -10% 0px', threshold:0.12 });
-    toReveal.forEach((el,i)=>{ el.style.transitionDelay = `${Math.min(i*40,240)}ms`; io.observe(el); });
-
-    const headerEl = document.getElementById('site-header');
-    function onScroll(){ if(window.scrollY>4) headerEl.classList.add('scrolled'); else headerEl.classList.remove('scrolled'); }
-    onScroll(); window.addEventListener('scroll', onScroll, { passive:true });
-
-    function istTime(){ try { return new Intl.DateTimeFormat('en-IN', { timeStyle:'short', timeZone:'Asia/Kolkata' }).format(new Date()); } catch { return '--:--'; } }
-    function tick(){
-      const t = istTime();
-      document.querySelectorAll('[data-ist]').forEach(el=> el.textContent = `🕒 ${t} IST`);
-      const today = new Date().toISOString().slice(0,10);
-      const td = document.getElementById('today'); if (td) td.textContent = today;
-    }
-    tick(); setInterval(tick, 60000);
-
-    const copyBtn = document.getElementById('copy-email');
-    const emailLink = document.getElementById('email-link');
-    if (copyBtn && emailLink) copyBtn.addEventListener('click', async (e)=>{
-      e.preventDefault();
-      try { await navigator.clipboard.writeText(emailLink.textContent.trim()); copyBtn.textContent='Copied ✓'; setTimeout(()=>copyBtn.textContent='Copy',1500); } catch {}
-    });
-
-    const setBtn = document.getElementById('set-weather');
-    const weatherEl = document.getElementById('weather');
-    if (setBtn && weatherEl) setBtn.addEventListener('click', ()=>{
-      const temp = prompt('Temperature in °C (e.g., 29)');
-      const cond = prompt('Condition (e.g., Cloudy, Clear, Rain)');
-      if (temp) weatherEl.textContent = `${cond ? cond+' ' : ''}${temp}°C`;
-    });
-  </script>
-
+  <script src="assets/js/site.js" defer></script>
 </body></html>

--- a/contact.html
+++ b/contact.html
@@ -82,22 +82,8 @@
     @media (prefers-reduced-motion: reduce) { .reveal, .hover-lift, .tilt-oscillate { transition:none!important; animation:none!important; } }
   </style>
 </head>
-<body class="text-ink antialiased">
-  <header id="site-header" class="sticky top-0 z-20 border-b border-stroke/70 bg-white/80 backdrop-blur">
-    <nav class="mx-auto max-w-5xl px-5">
-      <div class="flex h-14 items-center gap-4">
-        <a href="index.html" class="font-display text-lg tracking-tight">Aditya Rao</a>
-        <div class="ml-auto flex items-center gap-5 text-sm">
-          <a href="index.html" class="navlink">Home</a>
-          <a href="about.html" class="navlink">About</a>
-          <a href="comingsoon.html" class="navlink">Blog</a>
-          <a href="creations.html" class="navlink">Creations</a>
-          <span class="text-subink">Contact</span>
-          <a href="contact.html#book" class="rounded-full bg-blue-600 px-3 py-1 text-white">Say hi</a>
-        </div>
-      </div>
-    </nav>
-  </header>
+<body class="text-ink antialiased" data-page="contact">
+  <header data-component="site-header"></header>
 
 <main class="mx-auto max-w-5xl px-5 py-10">
 <header class="mb-8"><h1 class="font-display text-4xl leading-tight">Let’s Connect</h1>
@@ -145,12 +131,7 @@
 </div>
 </main>
 
-  <footer class="border-t border-stroke/70 py-8 text-xs text-subink">
-    <div class="mx-auto flex max-w-5xl items-center justify-between px-5">
-      <span>Made lightly.</span>
-      <span id="today"></span>
-    </div>
-  </footer>
+  <footer data-component="site-footer" data-footer-note="Made lightly."></footer>
 
 
 <script>
@@ -187,33 +168,6 @@
   });
 </script>
 
-<script>
-  /* keep the existing page interactions */
-  const toReveal = Array.from(document.querySelectorAll('.reveal'));
-  const io = new IntersectionObserver((entries)=>{
-    entries.forEach(e=>{ if(e.isIntersecting){ e.target.classList.add('in-view'); io.unobserve(e.target); } });
-  }, { rootMargin:'0px 0px -10% 0px', threshold:0.12 });
-  toReveal.forEach((el,i)=>{ el.style.transitionDelay = `${Math.min(i*40,240)}ms`; io.observe(el); });
-
-  const headerEl = document.getElementById('site-header');
-  function onScroll(){ if(window.scrollY>4) headerEl.classList.add('scrolled'); else headerEl.classList.remove('scrolled'); }
-  onScroll(); window.addEventListener('scroll', onScroll, { passive:true });
-
-  function istTime(){ try { return new Intl.DateTimeFormat('en-IN', { timeStyle:'short', timeZone:'Asia/Kolkata' }).format(new Date()); } catch { return '--:--'; } }
-  function tick(){
-    const t = istTime();
-    document.querySelectorAll('[data-ist]').forEach(el=> el.textContent = `🕒 ${t} IST`);
-    const today = new Date().toISOString().slice(0,10);
-    const td = document.getElementById('today'); if (td) td.textContent = today;
-  }
-  tick(); setInterval(tick, 60000);
-
-  const copyBtn = document.getElementById('copy-email');
-  const emailLink = document.getElementById('email-link');
-  if (copyBtn && emailLink) copyBtn.addEventListener('click', async (e)=>{
-    e.preventDefault();
-    try { await navigator.clipboard.writeText(emailLink.textContent.trim()); copyBtn.textContent='Copied ✓'; setTimeout(()=>copyBtn.textContent='Copy',1500); } catch {}
-  });
-</script>
+<script src="assets/js/site.js" defer></script>
 
 </body></html>

--- a/creations.html
+++ b/creations.html
@@ -37,22 +37,8 @@
     @media (prefers-reduced-motion: reduce) { .reveal, .hover-lift, .tilt-oscillate { transition:none!important; animation:none!important; } }
   </style>
 </head>
-<body class="text-ink antialiased">
-  <header id="site-header" class="sticky top-0 z-20 border-b border-stroke/70 bg-white/80 backdrop-blur">
-    <nav class="mx-auto max-w-5xl px-5">
-      <div class="flex h-14 items-center gap-4">
-        <a href="index.html" class="font-display text-lg tracking-tight">Aditya Rao</a>
-        <div class="ml-auto flex items-center gap-5 text-sm">
-          <a href="index.html" class="navlink">Home</a>
-          <a href="about.html" class="navlink">About</a>
-          <a href="comingsoon.html" class="navlink">Blog</a>
-          <span class="text-subink">Creations</span>
-          <a href="contact.html" class="navlink">Contact</a>
-          <a href="contact.html#book" class="rounded-full bg-blue-600 px-3 py-1 text-white">Say hi</a>
-        </div>
-      </div>
-    </nav>
-  </header>
+<body class="text-ink antialiased" data-page="creations">
+  <header data-component="site-header"></header>
 
 <main class="mx-auto max-w-5xl px-5 py-10">
 <header class="mb-6"><h1 class="font-display text-4xl leading-tight">Creations</h1><p class="text-subink">Here are some of the things I’ve been creating.</p></header>
@@ -64,46 +50,7 @@
 </div>
 </main>
 
-  <footer class="border-t border-stroke/70 py-8 text-xs text-subink">
-    <div class="mx-auto flex max-w-5xl items-center justify-between px-5">
-      <span>Today's Date: <span id="today"></span></span>
-    </div>
-  </footer>
+  <footer data-component="site-footer" data-footer-note="Today's Date:" data-footer-date-placement="inline"></footer>
 
-  <script>
-    const toReveal = Array.from(document.querySelectorAll('.reveal'));
-    const io = new IntersectionObserver((entries)=>{
-      entries.forEach(e=>{ if(e.isIntersecting){ e.target.classList.add('in-view'); io.unobserve(e.target); } });
-    }, { rootMargin:'0px 0px -10% 0px', threshold:0.12 });
-    toReveal.forEach((el,i)=>{ el.style.transitionDelay = `${Math.min(i*40,240)}ms`; io.observe(el); });
-
-    const headerEl = document.getElementById('site-header');
-    function onScroll(){ if(window.scrollY>4) headerEl.classList.add('scrolled'); else headerEl.classList.remove('scrolled'); }
-    onScroll(); window.addEventListener('scroll', onScroll, { passive:true });
-
-    function istTime(){ try { return new Intl.DateTimeFormat('en-IN', { timeStyle:'short', timeZone:'Asia/Kolkata' }).format(new Date()); } catch { return '--:--'; } }
-    function tick(){
-      const t = istTime();
-      document.querySelectorAll('[data-ist]').forEach(el=> el.textContent = `🕒 ${t} IST`);
-      const today = new Date().toISOString().slice(0,10);
-      const td = document.getElementById('today'); if (td) td.textContent = today;
-    }
-    tick(); setInterval(tick, 60000);
-
-    const copyBtn = document.getElementById('copy-email');
-    const emailLink = document.getElementById('email-link');
-    if (copyBtn && emailLink) copyBtn.addEventListener('click', async (e)=>{
-      e.preventDefault();
-      try { await navigator.clipboard.writeText(emailLink.textContent.trim()); copyBtn.textContent='Copied ✓'; setTimeout(()=>copyBtn.textContent='Copy',1500); } catch {}
-    });
-
-    const setBtn = document.getElementById('set-weather');
-    const weatherEl = document.getElementById('weather');
-    if (setBtn && weatherEl) setBtn.addEventListener('click', ()=>{
-      const temp = prompt('Temperature in °C (e.g., 29)');
-      const cond = prompt('Condition (e.g., Cloudy, Clear, Rain)');
-      if (temp) weatherEl.textContent = `${cond ? cond+' ' : ''}${temp}°C`;
-    });
-  </script>
-
+  <script src="assets/js/site.js" defer></script>
 </body></html>

--- a/index.html
+++ b/index.html
@@ -42,22 +42,8 @@
     @media (prefers-reduced-motion: reduce) { .reveal, .hover-lift, .tilt-oscillate { transition:none!important; animation:none!important; } }
   </style>
 </head>
-<body class="text-ink antialiased">
-  <header id="site-header" class="sticky top-0 z-20 border-b border-stroke/70 bg-white/80 backdrop-blur">
-    <nav class="mx-auto max-w-5xl px-5">
-      <div class="flex h-14 items-center gap-4">
-        <a href="index.html" class="font-display text-lg tracking-tight">Aditya Rao</a>
-        <div class="ml-auto flex items-center gap-5 text-sm">
-          <span class="text-subink">Home</span>
-          <a href="about.html" class="navlink">About</a>
-          <a href="comingsoon.html" class="navlink">Blog</a>
-          <a href="creations.html" class="navlink">Creations</a>
-          <a href="contact.html" class="navlink">Contact</a>
-          <a href="contact.html#book" class="rounded-full bg-blue-600 px-3 py-1 text-white">Say hi</a>
-        </div>
-      </div>
-    </nav>
-  </header>
+<body class="text-ink antialiased" data-page="home">
+  <header data-component="site-header"></header>
 
 <main class="mx-auto max-w-5xl px-5 py-8">
 <div class="mb-6 rounded-2xl border border-stroke bg-surface p-4 text-center text-sm text-subink shadow-card reveal">“Small steps every day.”</div>
@@ -83,7 +69,7 @@
 </section>
 <section class="mt-8 grid gap-6 md:grid-cols-3">
   <div class="md:col-span-2 rounded-2xl border border-stroke bg-surface p-5 shadow-card hover-lift reveal">
-    <div class="mb-2 flex items-end justify-between"><h2 class="font-display text-2xl">Featured projects</h2><a href="work.html" class="text-sm text-blue-700">View all →</a></div>
+    <div class="mb-2 flex items-end justify-between"><h2 class="font-display text-2xl">Featured projects</h2><a href="creations.html" class="text-sm text-blue-700">View all →</a></div>
     <div class="grid mt-5 gap-4 sm:grid-cols-2">
       <article class="rounded-xl border border-stroke p-4 hover-lift reveal"><div class="h-28 w-full rounded-md bg-[linear-gradient(135deg,#e5e7eb,#dbeafe)]"></div><h3 class="mt-3 font-medium">Cindral</h3><p class="text-sm text-subink">Short one-liner about the outcome.</p></article>
       <article class="rounded-xl border border-stroke p-4 hover-lift reveal"><div class="h-28 w-full rounded-md bg-[linear-gradient(135deg,#e5e7eb,#bfdbfe)]"></div><h3 class="mt-3 font-medium">MrVibe</h3><p class="text-sm text-subink">A concise explanation of impact.</p></article>
@@ -96,46 +82,7 @@
 </section>
 </main>
 
-  <footer class="border-t border-stroke/70 py-8 text-xs text-subink">
-    <div class="mx-auto flex max-w-5xl items-center justify-between px-5">
-      <span>Today's Date: <span id="today"></span></span>
-    </div>
-  </footer>
+  <footer data-component="site-footer" data-footer-note="Today's Date:" data-footer-date-placement="inline"></footer>
 
-  <script>
-    const toReveal = Array.from(document.querySelectorAll('.reveal'));
-    const io = new IntersectionObserver((entries)=>{
-      entries.forEach(e=>{ if(e.isIntersecting){ e.target.classList.add('in-view'); io.unobserve(e.target); } });
-    }, { rootMargin:'0px 0px -10% 0px', threshold:0.12 });
-    toReveal.forEach((el,i)=>{ el.style.transitionDelay = `${Math.min(i*40,240)}ms`; io.observe(el); });
-
-    const headerEl = document.getElementById('site-header');
-    function onScroll(){ if(window.scrollY>4) headerEl.classList.add('scrolled'); else headerEl.classList.remove('scrolled'); }
-    onScroll(); window.addEventListener('scroll', onScroll, { passive:true });
-
-    function istTime(){ try { return new Intl.DateTimeFormat('en-IN', { timeStyle:'short', timeZone:'Asia/Kolkata' }).format(new Date()); } catch { return '--:--'; } }
-    function tick(){
-      const t = istTime();
-      document.querySelectorAll('[data-ist]').forEach(el=> el.textContent = `🕒 ${t} IST`);
-      const today = new Date().toISOString().slice(0,10);
-      const td = document.getElementById('today'); if (td) td.textContent = today;
-    }
-    tick(); setInterval(tick, 60000);
-
-    const copyBtn = document.getElementById('copy-email');
-    const emailLink = document.getElementById('email-link');
-    if (copyBtn && emailLink) copyBtn.addEventListener('click', async (e)=>{
-      e.preventDefault();
-      try { await navigator.clipboard.writeText(emailLink.textContent.trim()); copyBtn.textContent='Copied ✓'; setTimeout(()=>copyBtn.textContent='Copy',1500); } catch {}
-    });
-
-    const setBtn = document.getElementById('set-weather');
-    const weatherEl = document.getElementById('weather');
-    if (setBtn && weatherEl) setBtn.addEventListener('click', ()=>{
-      const temp = prompt('Temperature in °C (e.g., 29)');
-      const cond = prompt('Condition (e.g., Cloudy, Clear, Rain)');
-      if (temp) weatherEl.textContent = `${cond ? cond+' ' : ''}${temp}°C`;
-    });
-  </script>
-
+  <script src="assets/js/site.js" defer></script>
 </body></html>

--- a/needs-wants.html
+++ b/needs-wants.html
@@ -39,46 +39,11 @@
     .chip { border:1px solid #E5EAF1; padding:.35rem .75rem; border-radius:9999px; white-space:nowrap; }
     .progress { height:8px; background:#E5EAF1; border-radius:9999px; overflow:hidden; }
     .progress>span { display:block; height:100%; background:#2563EB; width:var(--val,0%); transition:width .6s ease; }
-    .navlink { color: #5A6B85; transition: color .2s ease; }
-    .navlink:hover { color: #0B1220; }
     @media (prefers-reduced-motion: reduce) { .reveal, .hover-lift, .tilt-oscillate { transition:none!important; animation:none!important; } }
   </style>
 </head>
-<body class="text-ink antialiased">
-  <header id="site-header" class="sticky top-0 z-20 border-b border-stroke/70 bg-white/80 backdrop-blur">
-    <nav class="mx-auto max-w-5xl px-5">
-      <div class="flex h-14 items-center gap-4">
-        <a href="index.html" class="font-display text-lg tracking-tight">Aditya Rao</a>
-        <div class="ml-auto flex items-center gap-5 text-sm">
-          <a href="index.html" class="navlink">Home</a>
-          <a href="about.html" class="navlink">About</a>
-          <a href="comingsoon.html" class="navlink">Blog</a>
-          <a href="creations.html" class="navlink">Creations</a>
-          <div class="relative dropdown">
-            <button id="dropdownDefaultButton" data-dropdown-toggle="dropdown" class="navlink inline-flex items-center" type="button">
-              More 
-              <svg class="w-2.5 h-2.5 ms-2" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 10 6">
-                <path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="m1 1 4 4 4-4"/>
-              </svg>
-            </button>
-            <!-- Dropdown menu -->
-            <div id="dropdown" class="z-10 hidden bg-white divide-y divide-stroke rounded-lg shadow-card w-44 absolute right-0 mt-2 border border-stroke">
-              <ul class="py-2 text-sm text-ink" aria-labelledby="dropdownDefaultButton">
-                <li>
-                  <a href="now,someday.html" class="block px-4 py-2 hover:bg-subtle">Now, Someday</a>
-                </li>
-                <li>
-                  <span class="block px-4 py-2 text-subink bg-subtle">Needs and Wants</span>
-                </li>
-              </ul>
-            </div>
-          </div>
-          <a href="contact.html" class="navlink">Contact</a>
-          <a href="contact.html#book" class="rounded-full bg-blue-600 px-3 py-1 text-white">Say hi</a>
-        </div>
-      </div>
-    </nav>
-  </header>
+<body class="text-ink antialiased" data-page="needs-wants">
+  <header data-component="site-header"></header>
 
 <main class="mx-auto max-w-5xl px-5 py-8">
   <div class="mb-8 rounded-2xl border border-stroke bg-surface p-6 shadow-card reveal">
@@ -161,60 +126,14 @@
   <div class="mt-8 rounded-2xl border border-stroke bg-surface p-6 text-center shadow-card reveal">
     <p class="text-subink italic">"The secret of happiness is not in doing what you want, but in wanting what you do."</p>
     <div class="mt-4 flex justify-center gap-3">
-      <a href="now,someday.html" class="rounded-full border border-stroke px-4 py-2 text-sm">View Now, Someday</a>
+      <a href="now-someday.html" class="rounded-full border border-stroke px-4 py-2 text-sm">View Now, Someday</a>
       <a href="contact.html" class="rounded-full bg-blue-600 px-4 py-2 text-sm text-white">Share Thoughts</a>
     </div>
   </div>
 </main>
 
-<footer class="border-t border-stroke/70 py-8 text-xs text-subink">
-  <div class="mx-auto flex max-w-5xl items-center justify-between px-5">
-    <span>Today's Date: <span id="today"></span></span>
-  </div>
-</footer>
+<footer data-component="site-footer" data-footer-note="Today's Date:" data-footer-date-placement="inline"></footer>
 
-<script>
-  const toReveal = Array.from(document.querySelectorAll('.reveal'));
-  const io = new IntersectionObserver((entries)=>{
-    entries.forEach(e=>{ if(e.isIntersecting){ e.target.classList.add('in-view'); io.unobserve(e.target); } });
-  }, { rootMargin:'0px 0px -10% 0px', threshold:0.12 });
-  toReveal.forEach((el,i)=>{ el.style.transitionDelay = `${Math.min(i*40,240)}ms`; io.observe(el); });
-
-  const headerEl = document.getElementById('site-header');
-  function onScroll(){ if(window.scrollY>4) headerEl.classList.add('scrolled'); else headerEl.classList.remove('scrolled'); }
-  onScroll(); window.addEventListener('scroll', onScroll, { passive:true });
-
-  function tick(){
-    const today = new Date().toISOString().slice(0,10);
-    const td = document.getElementById('today'); if (td) td.textContent = today;
-  }
-  tick(); setInterval(tick, 60000);
-
-  // Dropdown functionality
-  document.addEventListener('DOMContentLoaded', function() {
-    const dropdownButton = document.getElementById('dropdownDefaultButton');
-    const dropdownMenu = document.getElementById('dropdown');
-
-    if (dropdownButton && dropdownMenu) {
-      dropdownButton.addEventListener('click', function(e) {
-        e.preventDefault();
-        e.stopPropagation();
-        
-        if (dropdownMenu.classList.contains('hidden')) {
-          dropdownMenu.classList.remove('hidden');
-        } else {
-          dropdownMenu.classList.add('hidden');
-        }
-      });
-
-      // Close dropdown when clicking outside
-      document.addEventListener('click', function(e) {
-        if (!dropdownButton.contains(e.target) && !dropdownMenu.contains(e.target)) {
-          dropdownMenu.classList.add('hidden');
-        }
-      });
-    }
-  });
-</script>
+<script src="assets/js/site.js" defer></script>
 
 </body></html>

--- a/now-someday.html
+++ b/now-someday.html
@@ -39,46 +39,11 @@
     .chip { border:1px solid #E5EAF1; padding:.35rem .75rem; border-radius:9999px; white-space:nowrap; }
     .progress { height:8px; background:#E5EAF1; border-radius:9999px; overflow:hidden; }
     .progress>span { display:block; height:100%; background:#2563EB; width:var(--val,0%); transition:width .6s ease; }
-    .navlink { color: #5A6B85; transition: color .2s ease; }
-    .navlink:hover { color: #0B1220; }
     @media (prefers-reduced-motion: reduce) { .reveal, .hover-lift, .tilt-oscillate { transition:none!important; animation:none!important; } }
   </style>
 </head>
-<body class="text-ink antialiased">
-  <header id="site-header" class="sticky top-0 z-20 border-b border-stroke/70 bg-white/80 backdrop-blur">
-    <nav class="mx-auto max-w-5xl px-5">
-      <div class="flex h-14 items-center gap-4">
-        <a href="index.html" class="font-display text-lg tracking-tight">Aditya Rao</a>
-        <div class="ml-auto flex items-center gap-5 text-sm">
-          <a href="index.html" class="navlink">Home</a>
-          <a href="about.html" class="navlink">About</a>
-          <a href="comingsoon.html" class="navlink">Blog</a>
-          <a href="creations.html" class="navlink">Creations</a>
-          <div class="relative dropdown">
-            <button id="dropdownDefaultButton" data-dropdown-toggle="dropdown" class="navlink inline-flex items-center" type="button">
-              More 
-              <svg class="w-2.5 h-2.5 ms-2" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 10 6">
-                <path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="m1 1 4 4 4-4"/>
-              </svg>
-            </button>
-            <!-- Dropdown menu -->
-            <div id="dropdown" class="z-10 hidden bg-white divide-y divide-stroke rounded-lg shadow-card w-44 absolute right-0 mt-2 border border-stroke">
-              <ul class="py-2 text-sm text-ink" aria-labelledby="dropdownDefaultButton">
-                <li>
-                  <span class="block px-4 py-2 text-subink bg-subtle">Now, Someday</span>
-                </li>
-                <li>
-                  <a href="Needs and Wants.html" class="block px-4 py-2 hover:bg-subtle">Needs and Wants</a>
-                </li>
-              </ul>
-            </div>
-          </div>
-          <a href="contact.html" class="navlink">Contact</a>
-          <a href="contact.html#book" class="rounded-full bg-blue-600 px-3 py-1 text-white">Say hi</a>
-        </div>
-      </div>
-    </nav>
-  </header>
+<body class="text-ink antialiased" data-page="now-someday">
+  <header data-component="site-header"></header>
 
 <main class="mx-auto max-w-5xl px-5 py-8">
   <div class="mb-8 rounded-2xl border border-stroke bg-surface p-6 shadow-card reveal">
@@ -161,54 +126,8 @@
   </div>
 </main>
 
-<footer class="border-t border-stroke/70 py-8 text-xs text-subink">
-  <div class="mx-auto flex max-w-5xl items-center justify-between px-5">
-    <span>Today's Date: <span id="today"></span></span>
-  </div>
-</footer>
+<footer data-component="site-footer" data-footer-note="Today's Date:" data-footer-date-placement="inline"></footer>
 
-<script>
-  const toReveal = Array.from(document.querySelectorAll('.reveal'));
-  const io = new IntersectionObserver((entries)=>{
-    entries.forEach(e=>{ if(e.isIntersecting){ e.target.classList.add('in-view'); io.unobserve(e.target); } });
-  }, { rootMargin:'0px 0px -10% 0px', threshold:0.12 });
-  toReveal.forEach((el,i)=>{ el.style.transitionDelay = `${Math.min(i*40,240)}ms`; io.observe(el); });
-
-  const headerEl = document.getElementById('site-header');
-  function onScroll(){ if(window.scrollY>4) headerEl.classList.add('scrolled'); else headerEl.classList.remove('scrolled'); }
-  onScroll(); window.addEventListener('scroll', onScroll, { passive:true });
-
-  function tick(){
-    const today = new Date().toISOString().slice(0,10);
-    const td = document.getElementById('today'); if (td) td.textContent = today;
-  }
-  tick(); setInterval(tick, 60000);
-
-  // Dropdown functionality
-  document.addEventListener('DOMContentLoaded', function() {
-    const dropdownButton = document.getElementById('dropdownDefaultButton');
-    const dropdownMenu = document.getElementById('dropdown');
-
-    if (dropdownButton && dropdownMenu) {
-      dropdownButton.addEventListener('click', function(e) {
-        e.preventDefault();
-        e.stopPropagation();
-        
-        if (dropdownMenu.classList.contains('hidden')) {
-          dropdownMenu.classList.remove('hidden');
-        } else {
-          dropdownMenu.classList.add('hidden');
-        }
-      });
-
-      // Close dropdown when clicking outside
-      document.addEventListener('click', function(e) {
-        if (!dropdownButton.contains(e.target) && !dropdownMenu.contains(e.target)) {
-          dropdownMenu.classList.add('hidden');
-        }
-      });
-    }
-  });
-</script>
+<script src="assets/js/site.js" defer></script>
 
 </body></html>


### PR DESCRIPTION
## Summary
- extract the shared navigation, footer, and utility scripts into a reusable assets/js/site.js module
- update site pages to mount the common header/footer components and identify the active navigation item
- fix stale internal links while wiring the new menu dropdown entries for “Needs & Wants” and “Now & Someday”

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68e5ff8b3bb8832e9367250322e8c5e1