### PR TITLE
refactor: centralize theme styling

### DIFF
--- a/about.html
+++ b/about.html
@@ -5,41 +5,9 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Space+Grotesk:wght@500;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="assets/css/theme.css">
+  <script src="assets/js/tailwind-config.js"></script>
   <script src="https://cdn.tailwindcss.com"></script>
-  <script>
-    tailwind.config = {
-      theme: {
-        extend: {
-          colors: {
-            ink: '#0B1220', subink: '#5A6B85',
-            surface: '#FFFFFF', subtle: '#F7F9FC', stroke: '#E5EAF1',
-            blue: {50:'#EFF6FF',100:'#DBEAFE',200:'#BFDBFE',300:'#93C5FD',400:'#60A5FA',500:'#3B82F6',600:'#2563EB',700:'#1D4ED8'}
-          },
-          boxShadow: { card: '0 4px 20px rgba(11,18,32,0.06)' },
-          fontFamily: { sans:['Inter','system-ui','sans-serif'], display:['Space Grotesk','Inter','sans-serif'] },
-        }
-      }
-    }
-  </script>
-  <style>
-    .pfp {
-      background: url(/assets/img/aditya-cycling.jpg);
-      background-size: cover;
-    }
-    :root { --bg:#F7F9FC; }
-    body { background: var(--bg); }
-    header.scrolled { box-shadow: 0 6px 20px rgba(11,18,32,.06); }
-    .reveal { opacity:0; transform:translateY(8px); transition: opacity .6s ease, transform .6s ease; }
-    .reveal.in-view { opacity:1; transform:none; }
-    .hover-lift { transition: transform .25s ease, box-shadow .25s ease; }
-    .hover-lift:hover { transform: translateY(-4px); box-shadow: 0 10px 30px rgba(11,18,32,.08); }
-    .tilt-oscillate { animation: floatTilt 6s ease-in-out infinite; transform-origin:center; }
-    @keyframes floatTilt { 0%,100%{ transform: rotate(-2deg) translateY(0);} 50%{ transform: rotate(-1deg) translateY(-4px);} }
-    .chip { border:1px solid #E5EAF1; padding:.35rem .75rem; border-radius:9999px; white-space:nowrap; }
-    .progress { height:8px; background:#E5EAF1; border-radius:9999px; overflow:hidden; }
-    .progress>span { display:block; height:100%; background:#2563EB; width:var(--val,0%); transition:width .6s ease; }
-    @media (prefers-reduced-motion: reduce) { .reveal, .hover-lift, .tilt-oscillate { transition:none!important; animation:none!important; } }
-  </style>
 </head>
 <body class="text-ink antialiased" data-page="about">
   <header data-component="site-header"></header>

--- a/assets/css/theme.css
+++ b/assets/css/theme.css
@@ -1,0 +1,147 @@
+:root {
+  color-scheme: light;
+  /* Palette */
+  --ink: #0B1220;
+  --ink-rgb: 11 18 32;
+  --ink-subtle: #5A6B85;
+  --ink-subtle-rgb: 90 107 133;
+  --surface: #FFFFFF;
+  --surface-rgb: 255 255 255;
+  --surface-subtle: #F7F9FC;
+  --surface-subtle-rgb: 247 249 252;
+  --surface-strong: #EEF3FA;
+  --surface-strong-rgb: 238 243 250;
+  --stroke: #E5EAF1;
+  --stroke-rgb: 229 234 241;
+  --shadow-card: 0 4px 20px rgba(11, 18, 32, 0.06);
+  --shadow-lift: 0 10px 30px rgba(11, 18, 32, 0.08);
+
+  /* Accent blues */
+  --blue-50: #EFF6FF;
+  --blue-50-rgb: 239 246 255;
+  --blue-100: #DBEAFE;
+  --blue-100-rgb: 219 234 254;
+  --blue-200: #BFDBFE;
+  --blue-200-rgb: 191 219 254;
+  --blue-300: #93C5FD;
+  --blue-300-rgb: 147 197 253;
+  --blue-400: #60A5FA;
+  --blue-400-rgb: 96 165 250;
+  --blue-500: #3B82F6;
+  --blue-500-rgb: 59 130 246;
+  --blue-600: #2563EB;
+  --blue-600-rgb: 37 99 235;
+  --blue-700: #1D4ED8;
+  --blue-700-rgb: 29 78 216;
+
+  /* Radius scale */
+  --radius-xs: 0.375rem;
+  --radius-sm: 0.5rem;
+  --radius-md: 0.75rem;
+  --radius-lg: 1rem;
+  --radius-xl: 1.25rem;
+  --radius-2xl: 1.5rem;
+  --radius-pill: 9999px;
+
+  /* Motion tokens */
+  --motion-duration-sm: 0.25s;
+  --motion-duration-md: 0.4s;
+  --motion-duration-lg: 0.6s;
+  --motion-duration-xl: 6s;
+  --motion-ease-standard: cubic-bezier(0.2, 0, 0, 1);
+  --motion-ease-out: cubic-bezier(0.2, 0, 0, 1);
+  --motion-ease-in-out: ease-in-out;
+  --motion-translate-distance: 8px;
+}
+
+body {
+  background: var(--surface-subtle);
+  color: var(--ink);
+}
+
+header.scrolled {
+  box-shadow: 0 6px 20px rgba(11, 18, 32, 0.06);
+}
+
+.reveal {
+  opacity: 0;
+  transform: translateY(var(--motion-translate-distance));
+  transition: opacity var(--motion-duration-lg) var(--motion-ease-standard),
+    transform var(--motion-duration-lg) var(--motion-ease-standard);
+}
+
+.reveal.in-view {
+  opacity: 1;
+  transform: none;
+}
+
+.hover-lift {
+  transition: transform var(--motion-duration-sm) var(--motion-ease-out),
+    box-shadow var(--motion-duration-sm) var(--motion-ease-out);
+}
+
+.hover-lift:hover {
+  transform: translateY(-4px);
+  box-shadow: var(--shadow-lift);
+}
+
+.tilt-oscillate {
+  animation: floatTilt var(--motion-duration-xl) var(--motion-ease-in-out) infinite;
+  transform-origin: center;
+}
+
+@keyframes floatTilt {
+  0%,
+  100% {
+    transform: rotate(-2deg) translateY(0);
+  }
+  50% {
+    transform: rotate(-1deg) translateY(-4px);
+  }
+}
+
+.chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 0.35rem 0.75rem;
+  border-radius: var(--radius-pill);
+  border: 1px solid var(--stroke);
+  font-size: 0.8125rem;
+  white-space: nowrap;
+}
+
+.progress {
+  height: 8px;
+  background: var(--stroke);
+  border-radius: var(--radius-pill);
+  overflow: hidden;
+}
+
+.progress > span {
+  display: block;
+  height: 100%;
+  background: var(--blue-600);
+  width: var(--val, 0%);
+  transition: width var(--motion-duration-lg) var(--motion-ease-standard);
+}
+
+.pfp {
+  background: url(/assets/img/aditya-cycling.jpg);
+  background-size: cover;
+}
+
+.pfp2 {
+  background: url(/assets/img/aditya-douji.jpg);
+  background-size: cover;
+  background-position: 30% 20%;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .reveal,
+  .hover-lift,
+  .tilt-oscillate {
+    transition: none !important;
+    animation: none !important;
+  }
+}

--- a/assets/js/tailwind-config.js
+++ b/assets/js/tailwind-config.js
@@ -1,0 +1,50 @@
+window.tailwind = window.tailwind || {};
+window.tailwind.config = {
+  theme: {
+    extend: {
+      colors: {
+        ink: 'rgb(var(--ink-rgb) / <alpha-value>)',
+        subink: 'rgb(var(--ink-subtle-rgb) / <alpha-value>)',
+        surface: 'rgb(var(--surface-rgb) / <alpha-value>)',
+        subtle: 'rgb(var(--surface-subtle-rgb) / <alpha-value>)',
+        stroke: 'rgb(var(--stroke-rgb) / <alpha-value>)',
+        blue: {
+          50: 'rgb(var(--blue-50-rgb) / <alpha-value>)',
+          100: 'rgb(var(--blue-100-rgb) / <alpha-value>)',
+          200: 'rgb(var(--blue-200-rgb) / <alpha-value>)',
+          300: 'rgb(var(--blue-300-rgb) / <alpha-value>)',
+          400: 'rgb(var(--blue-400-rgb) / <alpha-value>)',
+          500: 'rgb(var(--blue-500-rgb) / <alpha-value>)',
+          600: 'rgb(var(--blue-600-rgb) / <alpha-value>)',
+          700: 'rgb(var(--blue-700-rgb) / <alpha-value>)'
+        }
+      },
+      boxShadow: {
+        card: 'var(--shadow-card)'
+      },
+      fontFamily: {
+        sans: ['Inter', 'system-ui', 'sans-serif'],
+        display: ['Space Grotesk', 'Inter', 'sans-serif']
+      },
+      borderRadius: {
+        xl: 'var(--radius-xl)',
+        '2xl': 'var(--radius-2xl)',
+        pill: 'var(--radius-pill)'
+      },
+      keyframes: {
+        fadeUp: {
+          '0%': { opacity: '0', transform: 'translateY(var(--motion-translate-distance))' },
+          '100%': { opacity: '1', transform: 'none' }
+        },
+        pulseLine: {
+          '0%, 100%': { width: '10%' },
+          '50%': { width: '70%' }
+        }
+      },
+      animation: {
+        fadeUp: 'fadeUp var(--motion-duration-lg) var(--motion-ease-standard) both',
+        pulseLine: 'pulseLine calc(var(--motion-duration-lg) * 4) var(--motion-ease-in-out) infinite'
+      }
+    }
+  }
+};

--- a/blog.html
+++ b/blog.html
@@ -5,37 +5,9 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Space+Grotesk:wght@500;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="assets/css/theme.css">
+  <script src="assets/js/tailwind-config.js"></script>
   <script src="https://cdn.tailwindcss.com"></script>
-  <script>
-    tailwind.config = {
-      theme: {
-        extend: {
-          colors: {
-            ink: '#0B1220', subink: '#5A6B85',
-            surface: '#FFFFFF', subtle: '#F7F9FC', stroke: '#E5EAF1',
-            blue: {50:'#EFF6FF',100:'#DBEAFE',200:'#BFDBFE',300:'#93C5FD',400:'#60A5FA',500:'#3B82F6',600:'#2563EB',700:'#1D4ED8'}
-          },
-          boxShadow: { card: '0 4px 20px rgba(11,18,32,0.06)' },
-          fontFamily: { sans:['Inter','system-ui','sans-serif'], display:['Space Grotesk','Inter','sans-serif'] },
-        }
-      }
-    }
-  </script>
-  <style>
-    :root { --bg:#F7F9FC; }
-    body { background: var(--bg); }
-    header.scrolled { box-shadow: 0 6px 20px rgba(11,18,32,.06); }
-    .reveal { opacity:0; transform:translateY(8px); transition: opacity .6s ease, transform .6s ease; }
-    .reveal.in-view { opacity:1; transform:none; }
-    .hover-lift { transition: transform .25s ease, box-shadow .25s ease; }
-    .hover-lift:hover { transform: translateY(-4px); box-shadow: 0 10px 30px rgba(11,18,32,.08); }
-    .tilt-oscillate { animation: floatTilt 6s ease-in-out infinite; transform-origin:center; }
-    @keyframes floatTilt { 0%,100%{ transform: rotate(-2deg) translateY(0);} 50%{ transform: rotate(-1deg) translateY(-4px);} }
-    .chip { border:1px solid #E5EAF1; padding:.35rem .75rem; border-radius:9999px; white-space:nowrap; }
-    .progress { height:8px; background:#E5EAF1; border-radius:9999px; overflow:hidden; }
-    .progress>span { display:block; height:100%; background:#2563EB; width:var(--val,0%); transition:width .6s ease; }
-    @media (prefers-reduced-motion: reduce) { .reveal, .hover-lift, .tilt-oscillate { transition:none!important; animation:none!important; } }
-  </style>
 </head>
 <body class="text-ink antialiased" data-page="blog">
   <header data-component="site-header"></header>

--- a/comingsoon.html
+++ b/comingsoon.html
@@ -8,32 +8,9 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Space+Grotesk:wght@500;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="assets/css/theme.css">
+  <script src="assets/js/tailwind-config.js"></script>
   <script src="https://cdn.tailwindcss.com"></script>
-  <script>
-    tailwind.config = {
-      theme: {
-        extend: {
-          colors: {
-            ink: '#0B1220', subink: '#5A6B85',
-            surface: '#FFFFFF', subtle: '#F7F9FC', stroke: '#E5EAF1',
-            blue: {50:'#EFF6FF',100:'#DBEAFE',200:'#BFDBFE',300:'#93C5FD',400:'#60A5FA',500:'#3B82F6',600:'#2563EB',700:'#1D4ED8'}
-          },
-          boxShadow: { card: '0 8px 28px rgba(11,18,32,0.06)' },
-          fontFamily: { sans:['Inter','system-ui','sans-serif'], display:['Space Grotesk','Inter','sans-serif'] },
-          keyframes: {
-            fadeUp: { '0%':{opacity:0,transform:'translateY(8px)'}, '100%':{opacity:1,transform:'none'} },
-            pulseLine: { '0%,100%':{ width:'10%' }, '50%':{ width:'70%' } }
-          },
-          animation: { fadeUp:'fadeUp .6s ease both', pulseLine:'pulseLine 2.4s ease-in-out infinite' }
-        }
-      }
-    }
-  </script>
-  <style>
-    :root { --bg:#F7F9FC; }
-    body { background: var(--bg); }
-    .card { @apply rounded-2xl border border-stroke bg-surface shadow-card; }
-  </style>
 </head>
 <body class="text-ink antialiased">
   <!-- Header -->

--- a/contact.html
+++ b/contact.html
@@ -5,6 +5,8 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Space+Grotesk:wght@500;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="assets/css/theme.css">
+  <script src="assets/js/tailwind-config.js"></script>
   <script src="https://cdn.tailwindcss.com"></script>
 
   <!-- Leaflet (no keys needed) -->
@@ -13,36 +15,20 @@
 <script src="https://unpkg.com/topojson-client@3"></script>
 
 
-  <script>
-    tailwind.config = {
-      theme: {
-        extend: {
-          colors: {
-            ink: '#0B1220', subink: '#5A6B85',
-            surface: '#FFFFFF', subtle: '#F7F9FC', stroke: '#E5EAF1',
-            blue: {50:'#EFF6FF',100:'#DBEAFE',200:'#BFDBFE',300:'#93C5FD',400:'#60A5FA',500:'#3B82F6',600:'#2563EB',700:'#1D4ED8'}
-          },
-          boxShadow: { card: '0 4px 20px rgba(11,18,32,0.06)' },
-          fontFamily: { sans:['Inter','system-ui','sans-serif'], display:['Space Grotesk','Inter','sans-serif'] },
-        }
-      }
-    }
-  </script>
-
 <style>
   /* Card layout for the widget */
   .whereami {
-    border-radius: 16px;
-    border: 1px solid rgba(0,0,0,.08);
-    background: #fff;
-    box-shadow: 0 10px 30px rgba(11,18,32,.08);
+    border-radius: var(--radius-2xl);
+    border: 1px solid var(--stroke);
+    background: var(--surface);
+    box-shadow: var(--shadow-lift);
     overflow: hidden;
     display: grid;
     grid-template-columns: minmax(220px, 42%) 1fr;
   }
 
   /* Map pane (forced light theme) */
-  #map-navi { height: 230px; background: #f2f2f2; }
+  #map-navi { height: 230px; background: var(--surface-strong); }
   .leaflet-container { background: transparent; }
   .leaflet-tile { border:0!important; outline:1px solid transparent; }
   .leaflet-control-container { display: none; } /* hides zoom + attribution UI */
@@ -50,10 +36,10 @@
   /* Info pane */
   .wa-body { padding: 16px 18px; display: flex; flex-direction: column; justify-content: center; }
   .wa-title { font-family: ui-rounded, SF Pro Rounded, Inter, system-ui, sans-serif; font-weight: 700; letter-spacing: .2px; }
-  .wa-sub { color: #5A6B85; }
+  .wa-sub { color: var(--ink-subtle); }
 
   /* Chips */
-  .chip { display:inline-flex; align-items:center; gap:.4rem; font-size: 12px; padding:.35rem .6rem; border-radius:9999px; border:1px solid rgba(0,0,0,.08); }
+  .chip { font-size: 12px; padding:.35rem .6rem; }
 
   /* City pill overlay on map */
   .pill {
@@ -62,25 +48,9 @@
     font:600 11px/1.2 system-ui,-apple-system,Segoe UI,Inter,sans-serif;
     text-transform:uppercase; letter-spacing:.06em;
     backdrop-filter: blur(6px);
-    color:#111827; background:rgba(255,255,255,.65); border:1px solid rgba(0,0,0,.08);
+    color:var(--ink); background:rgba(255,255,255,.65); border:1px solid rgba(0,0,0,.08);
   }
 </style>
-
-  <style>
-    :root { --bg:#F7F9FC; }
-    body { background: var(--bg); }
-    header.scrolled { box-shadow: 0 6px 20px rgba(11,18,32,.06); }
-    .reveal { opacity:0; transform:translateY(8px); transition: opacity .6s ease, transform .6s ease; }
-    .reveal.in-view { opacity:1; transform:none; }
-    .hover-lift { transition: transform .25s ease, box-shadow .25s ease; }
-    .hover-lift:hover { transform: translateY(-4px); box-shadow: 0 10px 30px rgba(11,18,32,.08); }
-    .tilt-oscillate { animation: floatTilt 6s ease-in-out infinite; transform-origin:center; }
-    @keyframes floatTilt { 0%,100%{ transform: rotate(-2deg) translateY(0);} 50%{ transform: rotate(-1deg) translateY(-4px);} }
-    .chip { border:1px solid #E5EAF1; padding:.35rem .75rem; border-radius:9999px; white-space:nowrap; }
-    .progress { height:8px; background:#E5EAF1; border-radius:9999px; overflow:hidden; }
-    .progress>span { display:block; height:100%; background:#2563EB; width:var(--val,0%); transition:width .6s ease; }
-    @media (prefers-reduced-motion: reduce) { .reveal, .hover-lift, .tilt-oscillate { transition:none!important; animation:none!important; } }
-  </style>
 </head>
 <body class="text-ink antialiased" data-page="contact">
   <header data-component="site-header"></header>

--- a/creations.html
+++ b/creations.html
@@ -5,37 +5,9 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Space+Grotesk:wght@500;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="assets/css/theme.css">
+  <script src="assets/js/tailwind-config.js"></script>
   <script src="https://cdn.tailwindcss.com"></script>
-  <script>
-    tailwind.config = {
-      theme: {
-        extend: {
-          colors: {
-            ink: '#0B1220', subink: '#5A6B85',
-            surface: '#FFFFFF', subtle: '#F7F9FC', stroke: '#E5EAF1',
-            blue: {50:'#EFF6FF',100:'#DBEAFE',200:'#BFDBFE',300:'#93C5FD',400:'#60A5FA',500:'#3B82F6',600:'#2563EB',700:'#1D4ED8'}
-          },
-          boxShadow: { card: '0 4px 20px rgba(11,18,32,0.06)' },
-          fontFamily: { sans:['Inter','system-ui','sans-serif'], display:['Space Grotesk','Inter','sans-serif'] },
-        }
-      }
-    }
-  </script>
-  <style>
-    :root { --bg:#F7F9FC; }
-    body { background: var(--bg); }
-    header.scrolled { box-shadow: 0 6px 20px rgba(11,18,32,.06); }
-    .reveal { opacity:0; transform:translateY(8px); transition: opacity .6s ease, transform .6s ease; }
-    .reveal.in-view { opacity:1; transform:none; }
-    .hover-lift { transition: transform .25s ease, box-shadow .25s ease; }
-    .hover-lift:hover { transform: translateY(-4px); box-shadow: 0 10px 30px rgba(11,18,32,.08); }
-    .tilt-oscillate { animation: floatTilt 6s ease-in-out infinite; transform-origin:center; }
-    @keyframes floatTilt { 0%,100%{ transform: rotate(-2deg) translateY(0);} 50%{ transform: rotate(-1deg) translateY(-4px);} }
-    .chip { border:1px solid #E5EAF1; padding:.35rem .75rem; border-radius:9999px; white-space:nowrap; }
-    .progress { height:8px; background:#E5EAF1; border-radius:9999px; overflow:hidden; }
-    .progress>span { display:block; height:100%; background:#2563EB; width:var(--val,0%); transition:width .6s ease; }
-    @media (prefers-reduced-motion: reduce) { .reveal, .hover-lift, .tilt-oscillate { transition:none!important; animation:none!important; } }
-  </style>
 </head>
 <body class="text-ink antialiased" data-page="creations">
   <header data-component="site-header"></header>

--- a/index.html
+++ b/index.html
@@ -5,42 +5,9 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Space+Grotesk:wght@500;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="assets/css/theme.css">
+  <script src="assets/js/tailwind-config.js"></script>
   <script src="https://cdn.tailwindcss.com"></script>
-  <script>
-    tailwind.config = {
-      theme: {
-        extend: {
-          colors: {
-            ink: '#0B1220', subink: '#5A6B85',
-            surface: '#FFFFFF', subtle: '#F7F9FC', stroke: '#E5EAF1',
-            blue: {50:'#EFF6FF',100:'#DBEAFE',200:'#BFDBFE',300:'#93C5FD',400:'#60A5FA',500:'#3B82F6',600:'#2563EB',700:'#1D4ED8'}
-          },
-          boxShadow: { card: '0 4px 20px rgba(11,18,32,0.06)' },
-          fontFamily: { sans:['Inter','system-ui','sans-serif'], display:['Space Grotesk','Inter','sans-serif'] },
-        }
-      }
-    }
-  </script>
-  <style>
-    .pfp2 {
-      background: url(/assets/img/aditya-douji.jpg);
-      background-size: cover;
-      background-position: 30% 20%;
-    }
-    :root { --bg:#F7F9FC; }
-    body { background: var(--bg); }
-    header.scrolled { box-shadow: 0 6px 20px rgba(11,18,32,.06); }
-    .reveal { opacity:0; transform:translateY(8px); transition: opacity .6s ease, transform .6s ease; }
-    .reveal.in-view { opacity:1; transform:none; }
-    .hover-lift { transition: transform .25s ease, box-shadow .25s ease; }
-    .hover-lift:hover { transform: translateY(-4px); box-shadow: 0 10px 30px rgba(11,18,32,.08); }
-    .tilt-oscillate { animation: floatTilt 6s ease-in-out infinite; transform-origin:center; }
-    @keyframes floatTilt { 0%,100%{ transform: rotate(-2deg) translateY(0);} 50%{ transform: rotate(-1deg) translateY(-4px);} }
-    .chip { border:1px solid #E5EAF1; padding:.35rem .75rem; border-radius:9999px; white-space:nowrap; }
-    .progress { height:8px; background:#E5EAF1; border-radius:9999px; overflow:hidden; }
-    .progress>span { display:block; height:100%; background:#2563EB; width:var(--val,0%); transition:width .6s ease; }
-    @media (prefers-reduced-motion: reduce) { .reveal, .hover-lift, .tilt-oscillate { transition:none!important; animation:none!important; } }
-  </style>
 </head>
 <body class="text-ink antialiased" data-page="home">
   <header data-component="site-header"></header>

--- a/needs-wants.html
+++ b/needs-wants.html
@@ -5,42 +5,9 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Space+Grotesk:wght@500;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="assets/css/theme.css">
+  <script src="assets/js/tailwind-config.js"></script>
   <script src="https://cdn.tailwindcss.com"></script>
-  <script>
-    tailwind.config = {
-      theme: {
-        extend: {
-          colors: {
-            ink: '#0B1220', subink: '#5A6B85',
-            surface: '#FFFFFF', subtle: '#F7F9FC', stroke: '#E5EAF1',
-            blue: {50:'#EFF6FF',100:'#DBEAFE',200:'#BFDBFE',300:'#93C5FD',400:'#60A5FA',500:'#3B82F6',600:'#2563EB',700:'#1D4ED8'}
-          },
-          boxShadow: { card: '0 4px 20px rgba(11,18,32,0.06)' },
-          fontFamily: { sans:['Inter','system-ui','sans-serif'], display:['Space Grotesk','Inter','sans-serif'] },
-        }
-      }
-    }
-  </script>
-  <style>
-    .pfp2 {
-      background: url(/assets/img/aditya-douji.jpg);
-      background-size: cover;
-      background-position: 30% 20%;
-    }
-    :root { --bg:#F7F9FC; }
-    body { background: var(--bg); }
-    header.scrolled { box-shadow: 0 6px 20px rgba(11,18,32,.06); }
-    .reveal { opacity:0; transform:translateY(8px); transition: opacity .6s ease, transform .6s ease; }
-    .reveal.in-view { opacity:1; transform:none; }
-    .hover-lift { transition: transform .25s ease, box-shadow .25s ease; }
-    .hover-lift:hover { transform: translateY(-4px); box-shadow: 0 10px 30px rgba(11,18,32,.08); }
-    .tilt-oscillate { animation: floatTilt 6s ease-in-out infinite; transform-origin:center; }
-    @keyframes floatTilt { 0%,100%{ transform: rotate(-2deg) translateY(0);} 50%{ transform: rotate(-1deg) translateY(-4px);} }
-    .chip { border:1px solid #E5EAF1; padding:.35rem .75rem; border-radius:9999px; white-space:nowrap; }
-    .progress { height:8px; background:#E5EAF1; border-radius:9999px; overflow:hidden; }
-    .progress>span { display:block; height:100%; background:#2563EB; width:var(--val,0%); transition:width .6s ease; }
-    @media (prefers-reduced-motion: reduce) { .reveal, .hover-lift, .tilt-oscillate { transition:none!important; animation:none!important; } }
-  </style>
 </head>
 <body class="text-ink antialiased" data-page="needs-wants">
   <header data-component="site-header"></header>

--- a/now-someday.html
+++ b/now-someday.html
@@ -5,42 +5,9 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Space+Grotesk:wght@500;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="assets/css/theme.css">
+  <script src="assets/js/tailwind-config.js"></script>
   <script src="https://cdn.tailwindcss.com"></script>
-  <script>
-    tailwind.config = {
-      theme: {
-        extend: {
-          colors: {
-            ink: '#0B1220', subink: '#5A6B85',
-            surface: '#FFFFFF', subtle: '#F7F9FC', stroke: '#E5EAF1',
-            blue: {50:'#EFF6FF',100:'#DBEAFE',200:'#BFDBFE',300:'#93C5FD',400:'#60A5FA',500:'#3B82F6',600:'#2563EB',700:'#1D4ED8'}
-          },
-          boxShadow: { card: '0 4px 20px rgba(11,18,32,0.06)' },
-          fontFamily: { sans:['Inter','system-ui','sans-serif'], display:['Space Grotesk','Inter','sans-serif'] },
-        }
-      }
-    }
-  </script>
-  <style>
-    .pfp2 {
-      background: url(/assets/img/aditya-douji.jpg);
-      background-size: cover;
-      background-position: 30% 20%;
-    }
-    :root { --bg:#F7F9FC; }
-    body { background: var(--bg); }
-    header.scrolled { box-shadow: 0 6px 20px rgba(11,18,32,.06); }
-    .reveal { opacity:0; transform:translateY(8px); transition: opacity .6s ease, transform .6s ease; }
-    .reveal.in-view { opacity:1; transform:none; }
-    .hover-lift { transition: transform .25s ease, box-shadow .25s ease; }
-    .hover-lift:hover { transform: translateY(-4px); box-shadow: 0 10px 30px rgba(11,18,32,.08); }
-    .tilt-oscillate { animation: floatTilt 6s ease-in-out infinite; transform-origin:center; }
-    @keyframes floatTilt { 0%,100%{ transform: rotate(-2deg) translateY(0);} 50%{ transform: rotate(-1deg) translateY(-4px);} }
-    .chip { border:1px solid #E5EAF1; padding:.35rem .75rem; border-radius:9999px; white-space:nowrap; }
-    .progress { height:8px; background:#E5EAF1; border-radius:9999px; overflow:hidden; }
-    .progress>span { display:block; height:100%; background:#2563EB; width:var(--val,0%); transition:width .6s ease; }
-    @media (prefers-reduced-motion: reduce) { .reveal, .hover-lift, .tilt-oscillate { transition:none!important; animation:none!important; } }
-  </style>
 </head>
 <body class="text-ink antialiased" data-page="now-someday">
   <header data-component="site-header"></header>


### PR DESCRIPTION
## Summary
- add a shared theme stylesheet that defines palette, radius, motion, and utility classes for the site
- extract the Tailwind CDN configuration into a reusable script that references the new design tokens
- update every page head to consume the shared assets and clean up duplicate inline styles, including aligning the contact widget with the theme variables

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68e60c1eb5a8832e8c0fb631ae4f7903